### PR TITLE
Added Value Field to the Bot Message Sampler Used for handling Adaptive Cards submit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>br.com.microsoft.ocp</groupId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>jar</packaging>
 	<name>BotServiceStressToolkit</name>
 	<url>http://github.com/damadei/BotServiceStressToolkit</url>

--- a/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/builder/MessageActivityBuilder.java
+++ b/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/builder/MessageActivityBuilder.java
@@ -7,13 +7,15 @@ import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Conversation;
 import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Member;
 import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Message;
 
+import java.util.HashMap;
+
 public class MessageActivityBuilder extends ActivityBaseBuilder {
 
 	public MessageActivityBuilder() {
 	}
 
-	public static Message build(String conversationId, String text, String textFormat, String locale, Member from,
-			Member recipient, String channelId, String serviceUrl) {
+	public static Message build(String conversationId, String text, HashMap<String,String> value, String textFormat, String locale, Member from,
+								Member recipient, String channelId, String serviceUrl) {
 
 		Message message = new Message();
 		message.setType(Message.MESSAGE_TYPE);
@@ -21,7 +23,7 @@ public class MessageActivityBuilder extends ActivityBaseBuilder {
 		message.setLocale(locale);
 		message.setTextFormat(textFormat);
 		message.setText(text);
-
+        message.setValue(value);
 		message.setTimestamp(
 				ISODateTimeFormat.dateHourMinuteSecondMillis().withZoneUTC().print(System.currentTimeMillis()));
 		message.setTimestamp(ISODateTimeFormat.dateHourMinuteSecondMillis().withZone(DateTimeZone.forOffsetHours(-3))

--- a/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/plugin/schemas/Message.java
+++ b/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/plugin/schemas/Message.java
@@ -1,6 +1,7 @@
 package br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class Message extends Activity {
@@ -19,7 +20,7 @@ public class Message extends Activity {
 	private String attachmentLayout;
 	private String summary;
 	private SuggestedActions suggestedActions;
-	private String value;
+	private HashMap<String, String> value;
 	private String expiration;
 	private String importance;
 	private String deliveryMode;
@@ -96,11 +97,9 @@ public class Message extends Activity {
 		this.suggestedActions = suggestedActions;
 	}
 
-	public String getValue() {
-		return value;
-	}
+	public HashMap<String, String> getValue() { return value; }
 
-	public void setValue(String value) {
+	public void setValue(HashMap<String, String> value) {
 		this.value = value;
 	}
 

--- a/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/sampler/MessageSampler.java
+++ b/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/sampler/MessageSampler.java
@@ -1,5 +1,6 @@
 package br.com.microsoft.ocp.bot.service.jmeter.sampler;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 
@@ -20,6 +21,9 @@ import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Activity;
 import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Member;
 import br.com.microsoft.ocp.bot.service.jmeter.plugin.schemas.Message;
 
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
 public class MessageSampler extends BaseBotSampler {
 
 	private static final Logger log = LoggerFactory.getLogger(MessageSampler.class);
@@ -30,11 +34,13 @@ public class MessageSampler extends BaseBotSampler {
 	public static final String MESSAGE_TEXT = "MESSAGE_TEXT";
 	public static final String MESSAGE_TEXT_FORMAT = "MESSAGE_TEXT_FORMAT";
 	public static final String LOCALE = "LOCALE";
+	public static final String MESSAGE_VALUE = "MESSAGE_VALUE";
 
 	public static final int NUM_OF_EXPECTED_RESPONSES_DEFAULT_VALUE = 1;
 	public static final String MESSAGE_TEXT_DEFAULT_VALUE = "";
 	public static final String MESSAGE_TEXT_FORMAT_DEFAULT_VALUE = "plain";
 	public static final String LOCALE_DEFAULT_VALUE = "en-US";
+	public static final String MESSAGE_VALUE_DEFAULT_VALUE = "{}";
 
 	@Override
 	public SampleResult sample(Entry entry) {
@@ -49,7 +55,7 @@ public class MessageSampler extends BaseBotSampler {
 
 			String conversationId = vars.get(Constants.CONVERSATION_ID);
 
-			Message requestMessage = MessageActivityBuilder.build(conversationId, getMessageText(),
+			Message requestMessage = MessageActivityBuilder.build(conversationId, getMessageText(), getMessageValue(),
 					getMessageTextFormat(), getLocale(), new Member(getFromUser()), new Member(getRecipientMemberId()),
 					getChannelId(), getCallbackUrl());
 
@@ -103,6 +109,11 @@ public class MessageSampler extends BaseBotSampler {
 
 	public int getNumberOfResponseMessagesExpected() {
 		return getPropertyAsInt(NUM_OF_EXPECTED_RESPONSES);
+	}
+
+	private HashMap<String,String> getMessageValue() {
+			Jsonb jsonb = JsonbBuilder.create();
+		    return jsonb.fromJson(getPropertyAsString(MESSAGE_VALUE),new HashMap<String,String>().getClass());
 	}
 
 }

--- a/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/sampler/gui/MessageSamplerGui.java
+++ b/src/main/java/br/com/microsoft/ocp/bot/service/jmeter/sampler/gui/MessageSamplerGui.java
@@ -24,17 +24,21 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 	private static final String MESSAGE_TEXT_LABEL = "Text:";
 	private static final String MESSAGE_TEXT_FORMAT_LABEL = "Text Format:";
 	private static final String LOCALE_LABEL = "Locale:";
+	private static final String MESSAGE_VALUE_LABEL = "Value:";
 
 	private javax.swing.JLabel messageTextLabel = new JLabel();
 	private javax.swing.JLabel messageTextFormatLabel = new JLabel();
 	private javax.swing.JLabel localeLabel = new JLabel();
 	private javax.swing.JLabel numOfResponsesExpectedLabel = new JLabel();
 	private javax.swing.JScrollPane messageTextAreaScrollPane = new javax.swing.JScrollPane();
+	private javax.swing.JLabel messageValueLabel = new JLabel();
+	private javax.swing.JScrollPane messageValueAreaScrollPane = new javax.swing.JScrollPane();
 
 	private javax.swing.JTextArea messageTextTextArea = new JTextArea();
 	private javax.swing.JTextField messageTextFormatTextField = new JTextField();
 	private javax.swing.JTextField localeTextField = new JTextField();
 	private javax.swing.JTextField numOfResponsesExpectedTextField;
+	private javax.swing.JTextArea messageValueTextArea = new JTextArea();
 
 	public MessageSamplerGui() {
 		init();
@@ -56,6 +60,7 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 		messageTextTextArea.setText(element.getPropertyAsString(MessageSampler.MESSAGE_TEXT));
 		messageTextFormatTextField.setText(element.getPropertyAsString(MessageSampler.MESSAGE_TEXT_FORMAT));
 		localeTextField.setText(element.getPropertyAsString(MessageSampler.LOCALE));
+		messageValueTextArea.setText(element.getPropertyAsString(MessageSampler.MESSAGE_VALUE));
 	}
 
 	/**
@@ -81,6 +86,7 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 		te.setProperty(MessageSampler.MESSAGE_TEXT, messageTextTextArea.getText());
 		te.setProperty(MessageSampler.MESSAGE_TEXT_FORMAT, messageTextFormatTextField.getText());
 		te.setProperty(MessageSampler.LOCALE, localeTextField.getText());
+		te.setProperty(MessageSampler.MESSAGE_VALUE, messageValueTextArea.getText());
 	}
 
 	/*
@@ -102,6 +108,10 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 		messageTextTextArea.setRows(5);
 		messageTextAreaScrollPane.setViewportView(messageTextTextArea);
 
+		messageValueTextArea.setColumns(20);
+		messageValueTextArea.setRows(5);
+		messageValueAreaScrollPane.setViewportView(messageValueTextArea);
+
 		NumberFormat format = new DecimalFormat("#0");
 		NumberFormatter formatter = new NumberFormatter(format);
 		formatter.setValueClass(Integer.class);
@@ -115,6 +125,7 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 		messageTextLabel.setText(MESSAGE_TEXT_LABEL);
 		messageTextFormatLabel.setText(MESSAGE_TEXT_FORMAT_LABEL);
 		localeLabel.setText(LOCALE_LABEL);
+		messageValueLabel.setText(MESSAGE_VALUE_LABEL);
 
 		javax.swing.GroupLayout layout = new javax.swing.GroupLayout(mainPanel);
 		mainPanel.setLayout(layout);
@@ -131,6 +142,9 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 												javax.swing.GroupLayout.DEFAULT_SIZE,
 												javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
 										.addComponent(localeLabel, javax.swing.GroupLayout.DEFAULT_SIZE,
+												javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+										.addComponent(messageValueLabel, javax.swing.GroupLayout.Alignment.LEADING,
+												javax.swing.GroupLayout.DEFAULT_SIZE,
 												javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
 								.addComponent(numOfResponsesExpectedLabel))
 						.addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -142,6 +156,8 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 								.addComponent(messageTextFormatTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 244,
 										javax.swing.GroupLayout.PREFERRED_SIZE)
 								.addComponent(messageTextAreaScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 585,
+										javax.swing.GroupLayout.PREFERRED_SIZE)
+								.addComponent(messageValueAreaScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 585,
 										javax.swing.GroupLayout.PREFERRED_SIZE))
 						.addGap(0, 469, Short.MAX_VALUE)));
 		layout.setVerticalGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING).addGroup(layout
@@ -164,6 +180,11 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 						.addComponent(numOfResponsesExpectedLabel).addComponent(numOfResponsesExpectedTextField,
 								javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE,
 								javax.swing.GroupLayout.PREFERRED_SIZE))
+				.addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+				.addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+						.addComponent(messageValueAreaScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE,
+								javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+						.addGroup(layout.createSequentialGroup().addGap(30, 30, 30).addComponent(messageValueLabel)))
 				.addContainerGap(540, Short.MAX_VALUE)));
 	}
 
@@ -178,6 +199,7 @@ public class MessageSamplerGui extends AbstractSamplerGui {
 		messageTextTextArea.setText(MessageSampler.MESSAGE_TEXT_DEFAULT_VALUE);
 		messageTextFormatTextField.setText(MessageSampler.MESSAGE_TEXT_FORMAT_DEFAULT_VALUE);
 		localeTextField.setText(MessageSampler.LOCALE_DEFAULT_VALUE);
+		messageValueTextArea.setText(MessageSampler.MESSAGE_VALUE_DEFAULT_VALUE);
 	}
 
 	@Override


### PR DESCRIPTION
This Change will add a new field to the Bot Message Sampler. This allows JSON Vey value pairs to be sent as Activity Value to handle Adaptive Cards submit.

Fix for issue  #7 

![image](https://user-images.githubusercontent.com/30690070/142590005-2b68fcef-de36-4384-a91c-8fd65cf3278d.png)

Currently, there is no way to send a reply to the below sample Adaptive card which might become a blocker but with this change Activity values can be directly sent through the sampler.
![image](https://user-images.githubusercontent.com/30690070/142590346-c98c751c-3972-4e76-949e-d0079e919ad8.png)

```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.2",
    "body": [
        {
            "type": "TextBlock",
            "text": "Name:",
            "wrap": true
        },
        {
            "type": "Input.Text",
            "placeholder": "Placeholder text",
            "id": "Name"
        }
    ],
    "actions": [
        {
            "type": "Action.Submit",
            "title": "Submit"
        }
    ]
}
```
![image](https://user-images.githubusercontent.com/30690070/142591312-5dfcab56-e8d6-41a0-a08e-351270f70fe6.png)


Thanks,
Palanikumar